### PR TITLE
🙈 [Task-114] JWT, SSE 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/hanahakdangwebsocketserver/common/SnowFlakeGenerator.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/common/SnowFlakeGenerator.java
@@ -1,0 +1,66 @@
+package com.hanahakdangwebsocketserver.common;
+
+import java.time.Instant;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@NoArgsConstructor
+@Component
+public class SnowFlakeGenerator {
+
+  private static final int CASE_ONE_BITS = 10;
+  private static final int CASE_TWO_BITS = 9;
+  private static final int SEQUENCE_BITS = 4; // 중복 방지용
+
+  private static final int maxSequence = (int) (Math.pow(2, CASE_ONE_BITS) - 1); // 2^5-1
+
+  private static final long CUSTOM_EPOCH = 1735657200000L; // 2025-01-01 00:00:00; 41bit
+  private volatile long sequence = 0L;
+  private int case_one = 10;
+  private int case_two = 0;
+  private volatile long lastTimestamp = -1L;
+
+  private static long timestamp() {
+    return Instant.now().toEpochMilli() - CUSTOM_EPOCH; // 41비트를 맞춰주기 위함
+  }
+
+  public synchronized long nextId() {
+    long currentTimestamp = timestamp();
+
+    if (currentTimestamp < lastTimestamp) {
+      throw new IllegalStateException("Invalid System Clock!");
+    }
+
+    // 동일한 시간에 들어온 요청으로 판단
+    if (currentTimestamp == lastTimestamp) {
+      sequence = (sequence + 1) & maxSequence;
+      if (sequence == 0) {
+        currentTimestamp = waitNextMillis(currentTimestamp);
+      }
+    } else {
+      sequence = 0;
+    }
+
+    lastTimestamp = currentTimestamp;
+    return makeId(currentTimestamp);
+  }
+
+  private Long makeId(long currentTimestamp) {
+    long id = 0;
+
+    id |= (currentTimestamp << CASE_ONE_BITS + CASE_TWO_BITS + SEQUENCE_BITS);
+    id |= (case_one << CASE_TWO_BITS + SEQUENCE_BITS);
+    id |= (case_two << SEQUENCE_BITS);
+    id |= sequence;
+
+    return id;
+  }
+
+  private long waitNextMillis(long currentTimestamp) {
+    while (currentTimestamp == lastTimestamp) {
+      currentTimestamp = timestamp();
+    }
+    return currentTimestamp;
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/config/KafkaConsumerConfig.java
@@ -29,7 +29,7 @@ public class KafkaConsumerConfig {
   public Map<String, Object> consumerConfigs() {
     return Map.of(
         ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServerUrl,
-        ConsumerConfig.GROUP_ID_CONFIG, "websocket1",
+        ConsumerConfig.GROUP_ID_CONFIG, "notified-group",
         ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class,
         ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class
     );

--- a/src/main/java/com/hanahakdangwebsocketserver/config/TokenHandler.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/config/TokenHandler.java
@@ -1,0 +1,92 @@
+package com.hanahakdangwebsocketserver.config;
+
+import java.util.Date;
+import java.util.Optional;
+import javax.crypto.SecretKey;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class TokenHandler {
+
+  @Value("${spring.jwt.secret}")
+  private String secretKey;
+
+  private static final String TOKEN_PREFIX = "Bearer ";
+
+  public Long getUserId(HttpServletRequest request) {
+    String token = resolveTokenFromRequest(request);
+    if (validateToken(token)) {
+      return getUserIdFromToken(token).orElse(null);
+    }
+    return null;
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false;
+    }
+
+    try {
+      Claims claims = this.parseClaims(token);
+      boolean isValid = !claims.getExpiration().before(new Date());
+      log.info("유효한 토큰 여부: {}", isValid);
+      return isValid;
+    } catch (ExpiredJwtException e) {
+      log.warn("만료된 토큰: {}", token);
+      return false;
+    } catch (Exception e) {
+      log.warn("유효하지 않은 토큰: {}", token);
+      return false;
+    }
+  }
+
+  private Optional<Long> getUserIdFromToken(String token) {
+    try {
+      Object userId = this.parseClaims(token).get("id");
+      if (userId instanceof Number) {
+        return Optional.of(((Number) userId).longValue());
+      }
+      return Optional.empty();
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private Claims parseClaims(String token) {
+    SecretKey encryptedKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+
+    try {
+      return Jwts.parserBuilder().
+          setSigningKey(encryptedKey).build().parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      log.warn("JWT가 만료되었습니다: {}", e.getMessage());
+      return e.getClaims();
+    } catch (Exception e) {
+      log.error("JWT 파싱 중 오류 발생: {}", e.getMessage());
+      throw e; // validateToken 호출하는 쪽에서 이 예외를 캐치하도록 함
+    }
+  }
+
+  // request 헤더에서 token 가져오기
+  public String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader("Authorization");
+    if (token != null && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(7);
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/config/TokenHandler.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/config/TokenHandler.java
@@ -16,6 +16,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import static com.hanahakdangwebsocketserver.notification.enums.NotificationResponseExceptionEnum.UNAUTHORIZED_TOKEN;
+
 @Log4j2
 @Component
 @RequiredArgsConstructor
@@ -46,10 +48,10 @@ public class TokenHandler {
       return isValid;
     } catch (ExpiredJwtException e) {
       log.warn("만료된 토큰: {}", token);
-      return false;
+      throw UNAUTHORIZED_TOKEN.createResponseStatusException();  // 예외를 던지도록 변경
     } catch (Exception e) {
       log.warn("유효하지 않은 토큰: {}", token);
-      return false;
+      throw UNAUTHORIZED_TOKEN.createResponseStatusException();  // 예외를 던지도록 변경
     }
   }
 
@@ -76,7 +78,7 @@ public class TokenHandler {
       return e.getClaims();
     } catch (Exception e) {
       log.error("JWT 파싱 중 오류 발생: {}", e.getMessage());
-      throw e; // validateToken 호출하는 쪽에서 이 예외를 캐치하도록 함
+      throw UNAUTHORIZED_TOKEN.createResponseStatusException();
     }
   }
 

--- a/src/main/java/com/hanahakdangwebsocketserver/kafka/KafkaNotificationConsumer.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/kafka/KafkaNotificationConsumer.java
@@ -1,0 +1,31 @@
+package com.hanahakdangwebsocketserver.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.hanahakdangwebsocketserver.notification.dto.NotificationMessage;
+import static com.hanahakdangwebsocketserver.redis.RedisExceptionEnum.CANT_CONVERT_INTO_DTO;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class KafkaNotificationConsumer {
+
+  private final KafkaTemplate<Integer, byte[]> kafkaTemplate;
+  private final ObjectMapper objectMapper;
+
+  public NotificationMessage consume(ConsumerRecord<Integer, byte[]> record) {
+    try {
+      byte[] messageBytes = record.value();
+      return objectMapper.readValue(messageBytes,
+          NotificationMessage.class); // byte[] -> JSON -> 객체
+    } catch (Exception e) {
+      log.error(CANT_CONVERT_INTO_DTO.getMessage());
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/controller/NotificationController.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/controller/NotificationController.java
@@ -1,0 +1,33 @@
+package com.hanahakdangwebsocketserver.notification.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.hanahakdangwebsocketserver.config.TokenHandler;
+import com.hanahakdangwebsocketserver.notification.service.NotificationService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/notifications")
+public class NotificationController {
+
+  private final TokenHandler tokenHandler;
+  private final NotificationService notificationService;
+
+  @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public ResponseEntity<SseEmitter> subscribeSSE(
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
+      HttpServletRequest request
+  ) {
+    Long userId = tokenHandler.getUserId(request); // JWT에서 userId 추출
+    SseEmitter sseEmitter = notificationService.createEmitter(userId);
+    return ResponseEntity.ok(sseEmitter);
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/dto/NotificationMessage.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/dto/NotificationMessage.java
@@ -1,0 +1,35 @@
+package com.hanahakdangwebsocketserver.notification.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * 카프카에 발행(publish)될 메시지 타입을 정의
+ */
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class NotificationMessage {
+
+  private Long notificationId;
+
+  private Long receiverId;
+
+  private String type;
+
+  private String content;
+
+  private Boolean isSeen;
+
+  private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/enums/NotificationResponseExceptionEnum.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/enums/NotificationResponseExceptionEnum.java
@@ -1,0 +1,20 @@
+package com.hanahakdangwebsocketserver.notification.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationResponseExceptionEnum {
+  NOT_VALID_USERID(HttpStatus.BAD_REQUEST, "유요하지 않은 유저 아이디입니다."),
+  UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  public ResponseStatusException createResponseStatusException() {
+    return new ResponseStatusException(this.httpStatus, this.message);
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/listener/KafkaNotificationListener.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/listener/KafkaNotificationListener.java
@@ -1,9 +1,0 @@
-package com.hanahakdangwebsocketserver.notification.listener;
-
-
-import org.springframework.kafka.annotation.KafkaListener;
-
-
-public class KafkaNotificationListener {
-
-}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/repository/EmitterRepository.java
@@ -1,0 +1,15 @@
+package com.hanahakdangwebsocketserver.notification.repository;
+
+import java.util.Map;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+  SseEmitter saveEmitter(Long userId, String emitterId, SseEmitter emitter);
+
+  Map<String, SseEmitter> findEmittersByUserId(Long userId);
+
+  void deleteEmitter(Long userId, String emitterId);
+
+  void deleteAllEmittersByUserId(Long userId);
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,119 @@
+package com.hanahakdangwebsocketserver.notification.repository;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.hanahakdangwebsocketserver.redis.RedisBoundHash;
+import static com.hanahakdangwebsocketserver.redis.RedisExceptionEnum.ERROR_DURING_OPERATION;
+
+@Log4j2
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+  /**
+   * HTTP 1.1, 2.0 버전에서는 브라우저당 여러 개의 SSE 커넥션을 유지할 수 있기 때문에 동일 사용자가 사용하는 서로 다른 Emitter들도 구분할 필요가 있다.
+   * 이를 위해 Redis와 ConcurrentHashMap으로 관리한다.
+   */
+
+  private static final String SSE_USERS_KEY = "sse-users";
+
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>(); // 실제 SSE 객체 관리
+
+  private final RedisBoundHash<String> userEmittersRedisHash;
+  private final RedisTemplate<String, String> redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public EmitterRepositoryImpl(RedisTemplate<String, String> redisTemplate,
+      ObjectMapper objectMapper) {
+    this.userEmittersRedisHash = new RedisBoundHash<>(SSE_USERS_KEY, redisTemplate,
+        objectMapper);
+    this.redisTemplate = redisTemplate;
+    this.objectMapper = objectMapper;
+  }
+
+  private HashSet<String> getEmittersSetFromRedis(Long userId) throws JsonProcessingException {
+    String emittersString = userEmittersRedisHash.get(userId.toString(), String.class).orElse(null);
+    if (emittersString == null) {
+      return new HashSet<>();
+    }
+    return objectMapper.readValue(emittersString, new TypeReference<HashSet<String>>() {
+    });
+  }
+
+  private void removeUserEmittersFromRedis(Long userId) {
+    userEmittersRedisHash.delete(userId.toString());
+  }
+
+  @Override
+  public SseEmitter saveEmitter(Long userId, String emitterId, SseEmitter emitter) {
+    try {
+      HashSet<String> userEmittersSet = getEmittersSetFromRedis(userId);
+      userEmittersSet.add(emitterId);
+      userEmittersRedisHash.put(userId.toString(), userEmittersSet.toString());
+    } catch (JsonProcessingException e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+
+    emitters.put(emitterId, emitter);
+
+    log.info("Saved emitterId {} for userId {} in Redis Hash", emitterId, userId);
+
+    return emitter;
+  }
+
+  @Override
+  public Map<String, SseEmitter> findEmittersByUserId(Long userId) {
+
+    Map<String, SseEmitter> userEmittersMap = new ConcurrentHashMap<>();
+
+    try {
+      HashSet<String> userEmittersSet = getEmittersSetFromRedis(userId);
+      userEmittersSet.forEach(emitterId -> {
+        SseEmitter emitter = emitters.get(emitterId);
+        if (emitter != null) {
+          userEmittersMap.put(emitterId, emitter);
+        }
+      });
+    } catch (JsonProcessingException e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+
+    return userEmittersMap;
+  }
+
+  @Override
+  public void deleteEmitter(Long userId, String emitterId) {
+    try {
+      HashSet<String> userEmittersSet = getEmittersSetFromRedis(userId);
+      userEmittersSet.remove(emitterId);
+      userEmittersRedisHash.put(userId.toString(), userEmittersSet.toString());
+    } catch (JsonProcessingException e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+
+    emitters.remove(emitterId);
+
+    log.info("Deleted emitterId {} for userId {}", emitterId, userId);
+  }
+
+  @Override
+  public void deleteAllEmittersByUserId(Long userId) {
+    try {
+      HashSet<String> userEmittersSet = getEmittersSetFromRedis(userId);
+      userEmittersSet.forEach(emitters::remove); // emitter 객체 삭제
+      removeUserEmittersFromRedis(userId); // 레디스에서도 제거
+    } catch (JsonProcessingException e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+
+    log.info("Deleted all emitters for userId {}", userId);
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/notification/service/NotificationService.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/notification/service/NotificationService.java
@@ -1,0 +1,98 @@
+package com.hanahakdangwebsocketserver.notification.service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.hanahakdangwebsocketserver.common.SnowFlakeGenerator;
+import com.hanahakdangwebsocketserver.config.TokenHandler;
+import com.hanahakdangwebsocketserver.kafka.KafkaNotificationConsumer;
+import com.hanahakdangwebsocketserver.notification.dto.NotificationMessage;
+import com.hanahakdangwebsocketserver.notification.repository.EmitterRepository;
+import static com.hanahakdangwebsocketserver.notification.enums.NotificationResponseExceptionEnum.NOT_VALID_USERID;
+
+@Log4j2
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final static String KAFKA_TOPIC = "notification"; // topic 이름
+  private static final String SSE_NAME = "sse-notification";
+  private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 1시간
+
+  private final SnowFlakeGenerator snowFlakeGenerator;
+  private final EmitterRepository emitterRepository;
+  private final KafkaNotificationConsumer notificationConsumer;
+
+  public SseEmitter createEmitter(Long userId) throws ResponseStatusException {
+
+    if (userId == null) {
+      throw NOT_VALID_USERID.createResponseStatusException();
+    }
+
+    String emitterId = String.valueOf(snowFlakeGenerator.nextId());
+    SseEmitter emitter = emitterRepository.saveEmitter(userId, emitterId,
+        new SseEmitter(DEFAULT_TIMEOUT));
+
+    // SseEmitter가 완료되거나 타임아웃될 때 해당 SseEmitter를 emitterRepository에서 삭제
+    emitter.onCompletion(() -> emitterRepository.deleteEmitter(userId, emitterId));
+    emitter.onTimeout(() -> emitterRepository.deleteEmitter(userId, emitterId));
+
+    // 첫 접속 시 503 에러를 방지하기 위한 더미 이벤트 전송
+    String eventId = "CreatedAt:" + System.currentTimeMillis();
+    sendNotification(userId, emitter, eventId, emitterId, "EventStream Created.");
+
+    // TODO : 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+
+    return emitter;
+  }
+
+  @KafkaListener(topics = KAFKA_TOPIC, groupId = "notified-group")
+  public void listen(ConsumerRecord<Integer, byte[]> record) {
+    NotificationMessage message = notificationConsumer.consume(record);
+
+    Map<String, SseEmitter> emitters = emitterRepository.findEmittersByUserId(
+        message.getReceiverId());
+    emitters.forEach((emitterId, emitter) -> {
+      log.info("카프카에서 가져온 알림 전송 - emitter id: {}", emitterId);
+      sendNotification(message.getReceiverId(), emitter, message.getNotificationId().toString(),
+          emitterId, message);
+    });
+  }
+
+  /**
+   * 클라이언트와 연결된 Emitter 객체에 알림 send
+   *
+   * @param userId    클라이언트의 user id
+   * @param emitter   클라이언트와 연결된 Emitter 객체
+   * @param eventId   이벤트(알림) id
+   * @param emitterId Emitter 객체 id
+   * @param data      알림 DTO or 첫 연결 메시지
+   */
+  private void sendNotification(Long userId, SseEmitter emitter, String eventId, String emitterId,
+      Object data) {
+    try {
+      emitter.send(SseEmitter.event()
+          .id(eventId)
+          .name(SSE_NAME)
+          .data(data)
+          .reconnectTime(3000L)  // 클라이언트에서 연결이 끊기고 3초마다 재연결을 시도
+      );
+
+      log.info("클라이언트에게 알림 전송 - event id: {}", eventId);
+
+    } catch (IOException exception) {
+      emitterRepository.deleteEmitter(userId, emitterId);
+    }
+  }
+}

--- a/src/main/java/com/hanahakdangwebsocketserver/redis/RedisExceptionEnum.java
+++ b/src/main/java/com/hanahakdangwebsocketserver/redis/RedisExceptionEnum.java
@@ -1,0 +1,18 @@
+package com.hanahakdangwebsocketserver.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RedisExceptionEnum {
+  ERROR_DURING_OPERATION("작업 중 오류가 발생했습니다."),
+  CANT_GET_VALUE("value를 가져올 수 없습니다."),
+  CANT_DELETE_BY_KEY("key를 통해 삭제할 수 없습니다."),
+  CANT_CONVERT_INTO_JSON("json으로 변환할 수 없습니다."),
+  CANT_CONVERT_INTO_DTO("객체로 변환할 수 없습니다."),
+  CANT_DESERIALIZE_JSON("JSON 역직렬화 중 오류가 발생했습니다."); // 새 메시지 추가
+
+
+  private final String message;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,8 @@ classroom.chat.topic-name=chat
 notification.topic-name=notification
 spring.kafka.listener.concurrency=3
 spring.kafka.consumer.properties.partition.assignment.strategy=org.apache.kafka.clients.consumer.RoundRobinAssignor
+# JWT
+spring.jwt.secret=${JWT_SECRET_KEY}
 #---
 spring.config.activate.on-profile=local
 logging.level.com.hanahakdangwebsocketserver=DEBUG


### PR DESCRIPTION
## 변경사항

### AS-IS

- 헤더에서 JWT 토큰을 가져와 userId 추출
- SSE 연결 엔드포인트 구현
- Kafka listen ➡️ SSE send

유저 - SSE 객체 매핑 정보는 레디스에서 관리합니다. 
```
key: userId
value: Set<String> emitterId
```
실제 SSE 객체와 서버에서 ConcurrentHashMap으로 따로 관리합니다.
```
key: emitterId
value: emitter
```

### TO-BE

이제 SSE 가능!

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.